### PR TITLE
add android keystore to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ yarn-error.*
 # environmental
 /google-services.json
 /serviceaccount-key.json
+/simple-fast.keystore
+/@thomaslennon__simplefast.jks
+/.idea/


### PR DESCRIPTION
created android key (.jks) for expo builds on android. Added this key to the .gitignore