### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CICD-Full.yml
+++ b/.github/workflows/CICD-Full.yml
@@ -9,6 +9,9 @@ on:
     branches: [ main, develop ]
   workflow_dispatch:  # manual trigger
 
+permissions:
+  contents: read
+
 jobs:
   # code quality checking - runs for all branches/PRs
   lint_test:
@@ -133,6 +136,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-')
     runs-on: ubuntu-latest
     environment: Production
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       


### PR DESCRIPTION
Potential fix for [https://github.com/thomas-lennon-atu-ie/simplefastapp/security/code-scanning/4](https://github.com/thomas-lennon-atu-ie/simplefastapp/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow and each job, specifying the minimal permissions required. For the `Production Release` job, we will grant `contents: read` for accessing repository contents and `contents: write` for creating a GitHub Release. Other permissions, such as `id-token: write`, will not be included unless explicitly required.

The `permissions` block will be added at the workflow level to apply to all jobs, with job-specific overrides where necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
